### PR TITLE
Add missing configuration in "Readme.md" and package.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,10 @@ Language server features provided by [vue-language-server](https://www.npmjs.com
 - `vetur.completion.useScaffoldSnippets`: Enable/disable Vetur's built-in scaffolding snippets, default: `true`
 - `vetur.completion.tagCasing`: Casing conversion for tag completion, default: `"kebab"`
   Valid options: ["initial","kebab"]
+- `vetur.grammar.customBlocks`: Mapping from custom block tag name to language name. Used for generating grammar to support syntax highlighting for custom blocks, default: `{"docs":"md","i18n":"json"}`
 - `vetur.validation.template`: Validate vue-html in <template> using eslint-plugin-vue, default: `true`
+- `vetur.validation.templateProps`: Validate props usage in <template> region. Show error/warning for not passing declared props to child components and show error for passing wrongly typed interpolation expressions, default: `false`
+- `vetur.validation.interpolation`: Validate interpolations in <template> region using TypeScript language service, default: `true`
 - `vetur.validation.style`: Validate css/scss/less/postcss in <style>, default: `true`
 - `vetur.validation.script`: Validate js/ts in <script>, default: `true`
 - `vetur.format.enable`: Enable/disable the Vetur document formatter., default: `true`
@@ -44,12 +47,16 @@ Language server features provided by [vue-language-server](https://www.npmjs.com
 - `vetur.format.options.useTabs`: Use tabs for indentation. Inherited by all formatters., default: `false`
 - `vetur.format.defaultFormatter.html`: Default formatter for <template> region, default: `"prettier"`
   Valid options: ["none","prettyhtml","js-beautify-html","prettier"]
+- `vetur.format.defaultFormatter.pug`: Default formatter for <template lang='pug'> region, default: `"prettier"`
+  Valid options: ["none","prettier"]
 - `vetur.format.defaultFormatter.css`: Default formatter for <style> region, default: `"prettier"`
   Valid options: ["none","prettier"]
 - `vetur.format.defaultFormatter.postcss`: Default formatter for <style lang='postcss'> region, default: `"prettier"`
   Valid options: ["none","prettier"]
 - `vetur.format.defaultFormatter.scss`: Default formatter for <style lang='scss'> region, default: `"prettier"`
   Valid options: ["none","prettier"]
+- `vetur.format.defaultFormatter.sass`: Default formatter for <style lang='sass'> region, default: `"sass-formatter"`
+  Valid options: ["none","sass-formatter"]
 - `vetur.format.defaultFormatter.less`: Default formatter for <style lang='less'> region, default: `"prettier"`
   Valid options: ["none","prettier"]
 - `vetur.format.defaultFormatter.stylus`: Default formatter for <style lang='stylus'> region, default: `"stylus-supremacy"`
@@ -69,6 +76,7 @@ Language server features provided by [vue-language-server](https://www.npmjs.com
   1. Clone vuejs/vetur from GitHub, build it and point it to the ABSOLUTE path of `/server`.
   2. `yarn global add vue-language-server` and point Vetur to the installed location (`yarn global dir` + node_modules/vue-language-server)
 
+- `vetur.dev.vlsPort`: The port that VLS listens to. Can be used for attaching to the VLS Node process for debugging / profiling, default: `-1`
 - `vetur.dev.logLevel`: Log level for VLS, default: `"INFO"`
   Valid options: ["INFO","DEBUG"]
 - `vetur.experimental.templateInterpolationService`: Enable template interpolation service that offers diagnostics / hover / definition / references., default: `false`

--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,7 @@ Language server features provided by [vue-language-server](https://www.npmjs.com
 - `vetur.format.defaultFormatterOptions`: Options for all default formatters, default: `{"js-beautify-html":{"wrap_attributes":"force-expand-multiline"},"prettyhtml":{"printWidth":100,"singleQuote":false,"wrapAttributes":false,"sortAttributes":false}}`
 - `vetur.format.styleInitialIndent`: Whether to have initial indent for <style> region, default: `false`
 - `vetur.format.scriptInitialIndent`: Whether to have initial indent for <script> region, default: `false`
+- `vetur.languageFeatures.codeActions`: Whether to enable codeActions, default: `true`
 - `vetur.trace.server`: Traces the communication between VS Code and Vue Language Server., default: `"off"`
   Valid options: ["off","messages","verbose"]
 - `vetur.dev.vlsPath`: Path to VLS for Vetur developers. There are two ways of using it.

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ Language server features provided by [vue-language-server](https://www.npmjs.com
 - `vetur.format.enable`: Enable/disable the Vetur document formatter., default: `true`
 - `vetur.format.options.tabSize`: Number of spaces per indentation level. Inherited by all formatters., default: `2`
 - `vetur.format.options.useTabs`: Use tabs for indentation. Inherited by all formatters., default: `false`
-- `vetur.format.defaultFormatter.html`: Default formatter for <template> region, default: `"prettyhtml"`
+- `vetur.format.defaultFormatter.html`: Default formatter for <template> region, default: `"prettier"`
   Valid options: ["none","prettyhtml","js-beautify-html","prettier"]
 - `vetur.format.defaultFormatter.css`: Default formatter for <style> region, default: `"prettier"`
   Valid options: ["none","prettier"]

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
         },
         "vetur.format.defaultFormatter.html": {
           "type": "string",
-          "default": "prettyhtml",
+          "default": "prettier",
           "enum": [
             "none",
             "prettyhtml",
@@ -142,7 +142,7 @@
           ],
           "enumDescriptions": [
             "disable formatting",
-            "prettyhtml",
+            "🚧 [DEPRECATED] prettyhtml",
             "html formatter of js-beautify",
             "prettier"
           ],

--- a/package.json
+++ b/package.json
@@ -334,6 +334,11 @@
           "default": false,
           "description": "Whether to have initial indent for <script> region"
         },
+        "vetur.languageFeatures.codeActions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to enable codeActions"
+        },
         "vetur.trace.server": {
           "type": "string",
           "enum": [

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "vetur.validation.templateProps": {
           "type": "boolean",
           "default": false,
-          "description": "Validate props usage in <template> region. Show error/warning for not passing declared props to child components."
+          "description": "Validate props usage in <template> region. Show error/warning for not passing declared props to child components and show error for passing wrongly typed interpolation expressions"
         },
         "vetur.validation.interpolation": {
           "type": "boolean",


### PR DESCRIPTION
## Description

- I've added the configurations added by this [commit](https://github.com/neoclide/coc-vetur/commit/41718c4bc0489157df5aa8611959de33ba41aad0) to `Readme.md`.
- Added and adjusted configuration based on the latest package.json from vetur

## Add docs(Readme)

Added missing configration to readme.

- `vetur.grammar.customBlocks`
- `vetur.validation.templateProps`, (And update description in "package.json")
- `vetur.validation.interpolation`
- `vetur.format.defaultFormatter.pug`
- `vetur.format.defaultFormatter.sass`
- `vetur.dev.vlsPort`

## Add config

- Added the configuration of `vetur.languageFeatures.codeActions`
    - Ref: https://github.com/vuejs/vetur/blob/master/CHANGELOG.md#0280--2020-09-23--vsix

## Update config

- Change the default of `vetur.format.defaultFormatter.html` to "prettier".
    - Ref: https://github.com/vuejs/vetur/blob/master/CHANGELOG.md#0280--2020-09-23--vsix