### PR TITLE
fix: add missing enable config

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     "configuration": {
       "title": "Vetur",
       "properties": {
+        "vetur.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable coc-vetur extension."
+        },
         "vetur.ignoreProjectWarning": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
It support `"vetur.enable"` but it is not in config scheme.